### PR TITLE
Update ComCal

### DIFF
--- a/Comcal.md
+++ b/Comcal.md
@@ -7,6 +7,7 @@
 | Event Name | Location | Dates | Cost |
 |------------|----------|-------|------|
 | [MacAdmins Conference](https://macadmins.psu.edu) | State College, PA | 9-12 July 2019 | [$649 Early Bird until 13 May](http://www.cvent.com/events/2019-macadmins-conference-at-penn-state/event-summary-a861fd3e6e4a4837924577becde201cf.aspx) |
+| [VMworld 2019](https://www.vmworld.com/en/us/index.html) | San Francisco, CA | 25-29 August 2019 | $2195 [Check the EUC Track!](https://techzone.vmware.com/blog/technical-euc-sessions-vmworld-2019) |
 | [MacSysAdmin](http://macsysadmin.se/) | Göteborg, Sweden | 1-4 October 2019 | [11700 SEK](https://www.macsysadmin.se/register/register.php) |
 | [MacTech Conference](https://conference.mactech.com) | Los Angeles, CA | 15-18 October 2019 | [$999 Early Bird til 28 June](https://forms.mactech.com/fillsurvey.php?sid=676&rid=None) |
 | [Jamf Nation User Conference](https://www.jamf.com/events/jamf-nation-user-conference/2019/) | Minneapolis, MN | 12-14 November 2019 | [$799 Early Bird Rate ($699 for EDU)](https://www.cvent.com/events/jamf-nation-user-conference-2019/registration-7d9e9c5d913c4c38b847a10de4a84e25.aspx) |


### PR DESCRIPTION
Add VMworld 2019 with price and link to EUC-specific items (breakout sessions and Hands-on Labs).
The EUC track at VMworld is basically the replacement for the old AirWatch Connect conference.